### PR TITLE
Adding sample for continuation token usage with EmailClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Python virtual environment
+*/venv/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/send-email-advanced/README.md
+++ b/send-email-advanced/README.md
@@ -43,6 +43,10 @@ The advanced version of send-email includes the following sub samples.
 
 - ./send-email-advanced/send-email-multiple-recipients/send-email-multiple-recipients.py
 
+### Resume send email with continuation token
+
+- ./send-email-advanced/send-email-continuation-token/send-email-continuation-token.py
+
 ## Before running the sample for the first time
 
 1. Open an instance of PowerShell, Windows Terminal, Command Prompt or equivalent program and navigate to the directory that you'd like to clone the sample to.

--- a/send-email-advanced/send-email-continuation-token/send-email-continuation-token.py
+++ b/send-email-advanced/send-email-continuation-token/send-email-continuation-token.py
@@ -1,0 +1,47 @@
+from azure.communication.email import EmailClient
+
+connection_string = "<ACS_CONNECTION_STRING>"
+sender_address = "<SENDER_EMAIL_ADDRESS>"
+recipient_address = "<RECIPIENT_EMAIL_ADDRESS>"
+
+POLLER_WAIT_TIME = 10
+
+message = {
+    "senderAddress": sender_address,
+    "recipients":  {
+        "to": [{"address": recipient_address}],
+    },
+    "content": {
+        "subject": "Test email from Python Sample",
+        "plainText": "This is plaintext body of test email.",
+        "html": "<html><h1>This is the html body of test email.</h1></html>",
+    }
+}
+
+try:
+    client = EmailClient.from_connection_string(connection_string)
+    poller = client.begin_send(message);
+
+    # Pauses operation and saves state that can be used later to resume operation
+    token = poller.continuation_token()
+
+    new_client = EmailClient.from_connection_string(connection_string);
+    new_poller = new_client.begin_send(message, continuation_token=token);
+
+    time_elapsed = 0
+    while not new_poller.done():
+        print("Email send poller status: " + new_poller.status())
+
+        new_poller.wait(POLLER_WAIT_TIME)
+        time_elapsed += POLLER_WAIT_TIME
+
+        if time_elapsed > 18 * POLLER_WAIT_TIME:
+            raise RuntimeError("Polling timed out.")
+
+    if new_poller.result()["status"] == "Succeeded":
+        print(f"Successfully sent the email (operation id: {new_poller.result()['id']})")
+    else:
+        raise RuntimeError(str(new_poller.result()["error"]))
+    
+except Exception as ex:
+    print(ex)

--- a/send-email-advanced/send-email-continuation-token/send-email-continuation-token.py
+++ b/send-email-advanced/send-email-continuation-token/send-email-continuation-token.py
@@ -24,8 +24,9 @@ try:
     poller = client.begin_send(message);
 
     # Pauses operation and saves state that can be used later to resume operation
-    # Additional processing can be done between pausing and resuming the operation
     token = poller.continuation_token()
+
+    # Additional processing can be done here between pausing and resuming the operation
 
     new_client = EmailClient.from_connection_string(connection_string);
     new_poller = new_client.begin_send(message, continuation_token=token);

--- a/send-email-advanced/send-email-continuation-token/send-email-continuation-token.py
+++ b/send-email-advanced/send-email-continuation-token/send-email-continuation-token.py
@@ -5,6 +5,7 @@ sender_address = "<SENDER_EMAIL_ADDRESS>"
 recipient_address = "<RECIPIENT_EMAIL_ADDRESS>"
 
 POLLER_WAIT_TIME = 10
+MAX_POLLS = 18
 
 message = {
     "senderAddress": sender_address,
@@ -35,7 +36,7 @@ try:
         new_poller.wait(POLLER_WAIT_TIME)
         time_elapsed += POLLER_WAIT_TIME
 
-        if time_elapsed > 18 * POLLER_WAIT_TIME:
+        if time_elapsed > MAX_POLLS * POLLER_WAIT_TIME:
             raise RuntimeError("Polling timed out.")
 
     if new_poller.result()["status"] == "Succeeded":

--- a/send-email-advanced/send-email-continuation-token/send-email-continuation-token.py
+++ b/send-email-advanced/send-email-continuation-token/send-email-continuation-token.py
@@ -24,6 +24,7 @@ try:
     poller = client.begin_send(message);
 
     # Pauses operation and saves state that can be used later to resume operation
+    # Additional processing can be done between pausing and resuming the operation
     token = poller.continuation_token()
 
     new_client = EmailClient.from_connection_string(connection_string);


### PR DESCRIPTION
A customer had a use-case where they were starting polling with one thread, then finishing it in another thread. Creating this sample so it's clearer how continuation tokens can be used in these use-cases.